### PR TITLE
Adding addresses metadata to Component and API kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To address the limitation with the number of annotations, an `errors-markdown` o
 ## Inputs
 
 | Parameter              | Is Required | Default              | Description                                                                                                                                                                                                                                                                                          |
-|------------------------|-------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------- | ----------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `filename`             | false       | `./catalog-info.yml` | The name of the `catalog-info.yml` file.                                                                                                                                                                                                                                                             |
 | `fail-if-errors`       | false       | true                 | Error annotations are created for each validation error in the `catalog-info.yml` file but these errors won't cause the action to fail on their own.  If this flag is set the action will be marked as a failure if the `catalog-info.yml` file is missing, empty or contains any validation errors. |
 | `generate-job-summary` | false       | true                 | Flag that determines whether a job summary containing validation errors will be created.<ul><li>Only applicable when the file is invalid.</li><li>This is the same markdown data that is provided in the `errors-markdown` output.</li></ul>                                                         |
@@ -37,7 +37,7 @@ To address the limitation with the number of annotations, an `errors-markdown` o
 ## Outputs
 
 | Output            | Description                                                                                                                                                                                                           | Possible Values |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
 | `is-valid`        | A flag indicating whether the `catalog-info.yml` file is valid or not.                                                                                                                                                | true or false   |
 | `errors-markdown` | A markdown fragment containing the list of all validation errors in the `catalog-info.yml` file.  output is provided because GitHub limits the number of error annotations that can be created in a single run to 10. | true or false   |
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Validate catalog-info.yml
         id: catalogInfo
-        uses: im-open/validate-catalog-info@v1.0.0
+        uses: im-open/validate-catalog-info@v1.0.1
         with:
           filename: ./docs/catalog-info.yml # Defaults to ./catalog-info.yml
           fail-if-errors: false             # Defaults to true
@@ -84,7 +84,7 @@ When creating PRs, please review the following guidelines:
 This repo uses [git-version-lite] in its workflows to examine commit messages to determine whether to perform a major, minor or patch increment on merge if [source code] changes have been made.  The following table provides the fragment that should be included in a commit message to active different increment strategies.
 
 | Increment Type | Commit Message Fragment                     |
-|----------------|---------------------------------------------|
+| -------------- | ------------------------------------------- |
 | major          | +semver:breaking                            |
 | major          | +semver:major                               |
 | minor          | +semver:feature                             |

--- a/dist/index.js
+++ b/dist/index.js
@@ -29071,6 +29071,7 @@ var require_API_v1alpha1_schema = __commonJS({
                     type: 'array',
                     items: {
                       type: 'object',
+                      required: ['subdomain', 'path', 'envs'],
                       properties: {
                         subdomain: {
                           type: 'string',
@@ -29084,17 +29085,19 @@ var require_API_v1alpha1_schema = __commonJS({
                         },
                         envs: {
                           type: 'string',
-                          description: 'A space-separated list of environments where the entity is available.',
+                          description: 'A space-separated list of environments where the API is available.',
                           minLength: 1
                         }
                       },
                       examples: [
                         {
-                          subdomain: 'api',
-                          path: '/household',
-                          envs: 'dev qa stage prod'
+                          subdomain: 'techhub',
+                          path: '/',
+                          envs: 'uat prod'
                         }
-                      ]
+                      ],
+                      $comment:
+                        'Addresses is optional but cannot be empty.  If present, it should contain a list of address items.  Each address item has a required subdomain, path and envs property.'
                     }
                   },
                   examples: [
@@ -29107,9 +29110,12 @@ var require_API_v1alpha1_schema = __commonJS({
                         }
                       ]
                     }
-                  ]
+                  ],
+                  $comment:
+                    'The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain.'
                 }
-              }
+              },
+              $comment: 'It may contain an optional addresses property.'
             },
             spec: {
               type: 'object',
@@ -29211,39 +29217,17 @@ var require_Component_v1alpha1_schema = __commonJS({
           kind: 'Component',
           metadata: {
             name: 'appointment-manager-mfe',
-            description: 'Front end for setting up appointments'
-          },
-          spec: {
-            type: 'mfe',
-            lifecycle: 'maintaining',
-            owner: 'group:default/ce2'
-          }
-        },
-        {
-          apiVersion: 'backstage.io/v1alpha1',
-          kind: 'Component',
-          metadata: {
-            name: 'shopping-mfe',
-            title: 'Shopping MFE',
-            description: 'Front end for letting users shop for plans.',
-            annotations: {
-              'sumo.mktp.io/source-category': 'Shopping/MFE/<env>'
-            },
+            description: 'Front end for setting up appointments',
             addresses: {
-              'viabenefits.com': [
+              'mktp.io': [
                 {
-                  subdomain: 'my',
-                  path: '/shopping',
+                  subdomain: 'api',
+                  path: '/telappts',
                   envs: 'dev qa stage prod'
                 },
                 {
-                  subdomain: 'marketplace',
-                  path: '/shopping',
-                  envs: 'dev qa stage prod'
-                },
-                {
-                  subdomain: 'app',
-                  path: '/shopping',
+                  subdomain: 'telappts',
+                  path: '/tel-appointments',
                   envs: 'dev qa stage prod'
                 }
               ]
@@ -29252,7 +29236,7 @@ var require_Component_v1alpha1_schema = __commonJS({
           spec: {
             type: 'mfe',
             lifecycle: 'maintaining',
-            system: 'system:shopping'
+            owner: 'group:default/ce2'
           }
         }
       ],
@@ -29284,11 +29268,12 @@ var require_Component_v1alpha1_schema = __commonJS({
                 addresses: {
                   type: 'object',
                   description:
-                    'The addresses where the API can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.',
+                    'The addresses where the Component can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.',
                   additionalProperties: {
                     type: 'array',
                     items: {
                       type: 'object',
+                      required: ['subdomain', 'path', 'envs'],
                       properties: {
                         subdomain: {
                           type: 'string',
@@ -29302,33 +29287,37 @@ var require_Component_v1alpha1_schema = __commonJS({
                         },
                         envs: {
                           type: 'string',
-                          description: 'A space-separated list of environments where the entity is available.',
+                          description: 'A space-separated list of environments where the Component is available.',
                           minLength: 1
                         }
                       },
                       examples: [
                         {
-                          subdomain: 'marketplace',
-                          path: '/home',
+                          subdomain: 'api',
+                          path: '/telappts',
                           envs: 'dev qa stage prod'
                         }
-                      ]
+                      ],
+                      $comment:
+                        'Addresses is optional but cannot be empty.  If present, it should contain a list of address items.  Each address item has a required subdomain, path and envs property.'
                     }
                   },
                   examples: [
                     {
-                      'viabenefits.com': [
+                      'mktp.io': [
                         {
-                          subdomain: 'my',
-                          path: '/home',
+                          subdomain: 'api',
+                          path: '/telappts',
                           envs: 'dev qa stage prod'
                         }
                       ]
                     }
-                  ]
+                  ],
+                  $comment:
+                    'The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain.'
                 }
               },
-              $comment: 'It may contain an optional deployment-environments property.'
+              $comment: 'It may contain an optional deployment-environments or addresses property.'
             },
             spec: {
               type: 'object',

--- a/dist/index.js
+++ b/dist/index.js
@@ -29112,7 +29112,7 @@ var require_API_v1alpha1_schema = __commonJS({
                     }
                   ],
                   $comment:
-                    'The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain.'
+                    'Addresses should be have one or more domains as the property name and a corresponding list of address objects as the value for each domain property.'
                 }
               },
               $comment: 'It may contain an optional addresses property.'
@@ -29314,7 +29314,7 @@ var require_Component_v1alpha1_schema = __commonJS({
                     }
                   ],
                   $comment:
-                    'The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain.'
+                    'Addresses should be have one or more domains as the property name and a corresponding list of address objects as the value for each domain property.'
                 }
               },
               $comment: 'It may contain an optional deployment-environments or addresses property.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29029,7 +29029,16 @@ var require_API_v1alpha1_schema = __commonJS({
           kind: 'API',
           metadata: {
             name: 'appointment-manager-service',
-            description: 'Sets up appointments'
+            description: 'Sets up appointments',
+            addresses: {
+              'mktp.io': [
+                {
+                  subdomain: 'techhub',
+                  path: '/',
+                  envs: 'uat prod'
+                }
+              ]
+            }
           },
           spec: {
             type: 'openapi',
@@ -29050,6 +29059,57 @@ var require_API_v1alpha1_schema = __commonJS({
           properties: {
             kind: {
               enum: ['API']
+            },
+            metadata: {
+              type: 'object',
+              properties: {
+                addresses: {
+                  type: 'object',
+                  description:
+                    'The addresses where the API can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.',
+                  additionalProperties: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        subdomain: {
+                          type: 'string',
+                          description: 'The subdomain of the address.',
+                          minLength: 1
+                        },
+                        path: {
+                          type: 'string',
+                          description: 'The path of the address.',
+                          minLength: 1
+                        },
+                        envs: {
+                          type: 'string',
+                          description: 'A space-separated list of environments where the entity is available.',
+                          minLength: 1
+                        }
+                      },
+                      examples: [
+                        {
+                          subdomain: 'api',
+                          path: '/household',
+                          envs: 'dev qa stage prod'
+                        }
+                      ]
+                    }
+                  },
+                  examples: [
+                    {
+                      'mktp.io': [
+                        {
+                          subdomain: 'techhub',
+                          path: '/',
+                          envs: 'uat prod'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
             },
             spec: {
               type: 'object',
@@ -29158,6 +29218,42 @@ var require_Component_v1alpha1_schema = __commonJS({
             lifecycle: 'maintaining',
             owner: 'group:default/ce2'
           }
+        },
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            name: 'shopping-mfe',
+            title: 'Shopping MFE',
+            description: 'Front end for letting users shop for plans.',
+            annotations: {
+              'sumo.mktp.io/source-category': 'Shopping/MFE/<env>'
+            },
+            addresses: {
+              'viabenefits.com': [
+                {
+                  subdomain: 'my',
+                  path: '/shopping',
+                  envs: 'dev qa stage prod'
+                },
+                {
+                  subdomain: 'marketplace',
+                  path: '/shopping',
+                  envs: 'dev qa stage prod'
+                },
+                {
+                  subdomain: 'app',
+                  path: '/shopping',
+                  envs: 'dev qa stage prod'
+                }
+              ]
+            }
+          },
+          spec: {
+            type: 'mfe',
+            lifecycle: 'maintaining',
+            system: 'system:shopping'
+          }
         }
       ],
       allOf: [
@@ -29184,6 +29280,52 @@ var require_Component_v1alpha1_schema = __commonJS({
                     type: 'string',
                     examples: ['Dev', 'QA', 'Stage', 'Prod', 'UAT']
                   }
+                },
+                addresses: {
+                  type: 'object',
+                  description:
+                    'The addresses where the API can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.',
+                  additionalProperties: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        subdomain: {
+                          type: 'string',
+                          description: 'The subdomain of the address.',
+                          minLength: 1
+                        },
+                        path: {
+                          type: 'string',
+                          description: 'The path of the address.',
+                          minLength: 1
+                        },
+                        envs: {
+                          type: 'string',
+                          description: 'A space-separated list of environments where the entity is available.',
+                          minLength: 1
+                        }
+                      },
+                      examples: [
+                        {
+                          subdomain: 'marketplace',
+                          path: '/home',
+                          envs: 'dev qa stage prod'
+                        }
+                      ]
+                    }
+                  },
+                  examples: [
+                    {
+                      'viabenefits.com': [
+                        {
+                          subdomain: 'my',
+                          path: '/home',
+                          envs: 'dev qa stage prod'
+                        }
+                      ]
+                    }
+                  ]
                 }
               },
               $comment: 'It may contain an optional deployment-environments property.'

--- a/schema/API.v1alpha1.schema.json
+++ b/schema/API.v1alpha1.schema.json
@@ -50,6 +50,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "required": [
+                    "subdomain",
+                    "path",
+                    "envs"
+                  ],
                   "properties": {
                     "subdomain": {
                       "type": "string",
@@ -63,17 +68,18 @@
                     },
                     "envs": {
                       "type": "string",
-                      "description": "A space-separated list of environments where the entity is available.",
+                      "description": "A space-separated list of environments where the API is available.",
                       "minLength": 1
                     }
                   },
                   "examples": [
                     {
-                      "subdomain": "api",
-                      "path": "/household",
-                      "envs": "dev qa stage prod"
+                      "subdomain": "techhub",
+                      "path": "/",
+                      "envs": "uat prod"
                     }
-                  ]
+                  ],
+                  "$comment": "Addresses is optional but cannot be empty.  If present, it should contain a list of address items.  Each address item has a required subdomain, path and envs property."
                 }
               },
               "examples": [
@@ -86,9 +92,11 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "$comment": "The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain."
             }
-          }
+          },
+          "$comment": "It may contain an optional addresses property."
         },
         "spec": {
           "type": "object",

--- a/schema/API.v1alpha1.schema.json
+++ b/schema/API.v1alpha1.schema.json
@@ -63,7 +63,7 @@
                     },
                     "envs": {
                       "type": "string",
-                      "description": "The environments where the entity is available.",
+                      "description": "A space-separated list of environments where the entity is available.",
                       "minLength": 1
                     }
                   },

--- a/schema/API.v1alpha1.schema.json
+++ b/schema/API.v1alpha1.schema.json
@@ -93,7 +93,7 @@
                   ]
                 }
               ],
-              "$comment": "The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain."
+              "$comment": "Addresses should be have one or more domains as the property name and a corresponding list of address objects as the value for each domain property."
             }
           },
           "$comment": "It may contain an optional addresses property."

--- a/schema/API.v1alpha1.schema.json
+++ b/schema/API.v1alpha1.schema.json
@@ -9,7 +9,16 @@
       "kind": "API",
       "metadata": {
         "name": "appointment-manager-service",
-        "description": "Sets up appointments"
+        "description": "Sets up appointments",
+        "addresses": {
+          "mktp.io": [
+            {
+              "subdomain": "techhub",
+              "path": "/",
+              "envs": "uat prod"
+            }
+          ]
+        }
       },
       "spec": {
         "type": "openapi",
@@ -30,6 +39,56 @@
       "properties": {
         "kind": {
           "enum": ["API"]
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "addresses": {
+              "type": "object",
+              "description": "The addresses where the API can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "subdomain": {
+                      "type": "string",
+                      "description": "The subdomain of the address.",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string",
+                      "description": "The path of the address.",
+                      "minLength": 1
+                    },
+                    "envs": {
+                      "type": "string",
+                      "description": "The environments where the entity is available.",
+                      "minLength": 1
+                    }
+                  },
+                  "examples": [
+                    {
+                      "subdomain": "api",
+                      "path": "/household",
+                      "envs": "dev qa stage prod"
+                    }
+                  ]
+                }
+              },
+              "examples": [
+                {
+                  "mktp.io": [
+                    {
+                      "subdomain": "techhub",
+                      "path": "/",
+                      "envs": "uat prod"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         },
         "spec": {
           "type": "object",

--- a/schema/Component.v1alpha1.schema.json
+++ b/schema/Component.v1alpha1.schema.json
@@ -9,39 +9,17 @@
       "kind": "Component",
       "metadata": {
         "name": "appointment-manager-mfe",
-        "description": "Front end for setting up appointments"
-      },
-      "spec": {
-        "type": "mfe",
-        "lifecycle": "maintaining",
-        "owner": "group:default/ce2"
-      }
-    },
-    {
-      "apiVersion": "backstage.io/v1alpha1",
-      "kind": "Component",
-      "metadata": {
-        "name": "shopping-mfe",
-        "title": "Shopping MFE",
-        "description": "Front end for letting users shop for plans.",
-        "annotations": {
-          "sumo.mktp.io/source-category": "Shopping/MFE/<env>"
-        },
+        "description": "Front end for setting up appointments",
         "addresses": {
-          "viabenefits.com": [
+          "mktp.io": [
             {
-              "subdomain": "my",
-              "path": "/shopping",
+              "subdomain": "api",
+              "path": "/telappts",
               "envs": "dev qa stage prod"
             },
             {
-              "subdomain": "marketplace",
-              "path": "/shopping",
-              "envs": "dev qa stage prod"
-            },
-            {
-              "subdomain": "app",
-              "path": "/shopping",
+              "subdomain": "telappts",
+              "path": "/tel-appointments",
               "envs": "dev qa stage prod"
             }
           ]
@@ -50,7 +28,7 @@
       "spec": {
         "type": "mfe",
         "lifecycle": "maintaining",
-        "system": "system:shopping"
+        "owner": "group:default/ce2"
       }
     }
   ],
@@ -86,11 +64,16 @@
             },
             "addresses": {
               "type": "object",
-              "description": "The addresses where the API can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.",
+              "description": "The addresses where the Component can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.",
               "additionalProperties": {
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "required": [
+                    "subdomain",
+                    "path",
+                    "envs"
+                  ],
                   "properties": {
                     "subdomain": {
                       "type": "string",
@@ -104,33 +87,35 @@
                     },
                     "envs": {
                       "type": "string",
-                      "description": "A space-separated list of environments where the entity is available.",
+                      "description": "A space-separated list of environments where the Component is available.",
                       "minLength": 1
                     }
                   },
                   "examples": [
                     {
-                      "subdomain": "marketplace",
-                      "path": "/home",
+                      "subdomain": "api",
+                      "path": "/telappts",
                       "envs": "dev qa stage prod"
                     }
-                  ]
+                  ],
+                  "$comment": "Addresses is optional but cannot be empty.  If present, it should contain a list of address items.  Each address item has a required subdomain, path and envs property."
                 }
               },
               "examples": [
                 {
-                  "viabenefits.com": [
+                  "mktp.io": [
                     {
-                      "subdomain": "my",
-                      "path": "/home",
+                      "subdomain": "api",
+                      "path": "/telappts",
                       "envs": "dev qa stage prod"
                     }
                   ]
                 }
-              ]
+              ],
+              "$comment": "The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain."
             }
           },
-          "$comment": "It may contain an optional deployment-environments property."
+          "$comment": "It may contain an optional deployment-environments or addresses property."
         },
         "spec": {
           "type": "object",

--- a/schema/Component.v1alpha1.schema.json
+++ b/schema/Component.v1alpha1.schema.json
@@ -112,7 +112,7 @@
                   ]
                 }
               ],
-              "$comment": "The object should be populated with one or more domains as the property name and a list of populated address objects as the value for each domain."
+              "$comment": "Addresses should be have one or more domains as the property name and a corresponding list of address objects as the value for each domain property."
             }
           },
           "$comment": "It may contain an optional deployment-environments or addresses property."

--- a/schema/Component.v1alpha1.schema.json
+++ b/schema/Component.v1alpha1.schema.json
@@ -104,7 +104,7 @@
                     },
                     "envs": {
                       "type": "string",
-                      "description": "The environments where the entity is available.",
+                      "description": "A space-separated list of environments where the entity is available.",
                       "minLength": 1
                     }
                   },

--- a/schema/Component.v1alpha1.schema.json
+++ b/schema/Component.v1alpha1.schema.json
@@ -32,62 +32,17 @@
             {
               "subdomain": "my",
               "path": "/shopping",
-              "envs": "dev"
-            },
-            {
-              "subdomain": "my",
-              "path": "/shopping",
-              "envs": "qa"
-            },
-            {
-              "subdomain": "my",
-              "path": "/shopping",
-              "envs": "stage"
-            },
-            {
-              "subdomain": "my",
-              "path": "/shopping",
-              "envs": "prod"
+              "envs": "dev qa stage prod"
             },
             {
               "subdomain": "marketplace",
               "path": "/shopping",
-              "envs": "dev"
-            },
-            {
-              "subdomain": "marketplace",
-              "path": "/shopping",
-              "envs": "qa"
-            },
-            {
-              "subdomain": "marketplace",
-              "path": "/shopping",
-              "envs": "stage"
-            },
-            {
-              "subdomain": "marketplace",
-              "path": "/shopping",
-              "envs": "prod"
+              "envs": "dev qa stage prod"
             },
             {
               "subdomain": "app",
               "path": "/shopping",
-              "envs": "dev"
-            },
-            {
-              "subdomain": "app",
-              "path": "/shopping",
-              "envs": "qa"
-            },
-            {
-              "subdomain": "app",
-              "path": "/shopping",
-              "envs": "stage"
-            },
-            {
-              "subdomain": "app",
-              "path": "/shopping",
-              "envs": "prod"
+              "envs": "dev qa stage prod"
             }
           ]
         }

--- a/schema/Component.v1alpha1.schema.json
+++ b/schema/Component.v1alpha1.schema.json
@@ -16,6 +16,87 @@
         "lifecycle": "maintaining",
         "owner": "group:default/ce2"
       }
+    },
+    {
+      "apiVersion": "backstage.io/v1alpha1",
+      "kind": "Component",
+      "metadata": {
+        "name": "shopping-mfe",
+        "title": "Shopping MFE",
+        "description": "Front end for letting users shop for plans.",
+        "annotations": {
+          "sumo.mktp.io/source-category": "Shopping/MFE/<env>"
+        },
+        "addresses": {
+          "viabenefits.com": [
+            {
+              "subdomain": "my",
+              "path": "/shopping",
+              "envs": "dev"
+            },
+            {
+              "subdomain": "my",
+              "path": "/shopping",
+              "envs": "qa"
+            },
+            {
+              "subdomain": "my",
+              "path": "/shopping",
+              "envs": "stage"
+            },
+            {
+              "subdomain": "my",
+              "path": "/shopping",
+              "envs": "prod"
+            },
+            {
+              "subdomain": "marketplace",
+              "path": "/shopping",
+              "envs": "dev"
+            },
+            {
+              "subdomain": "marketplace",
+              "path": "/shopping",
+              "envs": "qa"
+            },
+            {
+              "subdomain": "marketplace",
+              "path": "/shopping",
+              "envs": "stage"
+            },
+            {
+              "subdomain": "marketplace",
+              "path": "/shopping",
+              "envs": "prod"
+            },
+            {
+              "subdomain": "app",
+              "path": "/shopping",
+              "envs": "dev"
+            },
+            {
+              "subdomain": "app",
+              "path": "/shopping",
+              "envs": "qa"
+            },
+            {
+              "subdomain": "app",
+              "path": "/shopping",
+              "envs": "stage"
+            },
+            {
+              "subdomain": "app",
+              "path": "/shopping",
+              "envs": "prod"
+            }
+          ]
+        }
+      },
+      "spec": {
+        "type": "mfe",
+        "lifecycle": "maintaining",
+        "system": "system:shopping"
+      }
     }
   ],
   "allOf": [
@@ -47,6 +128,51 @@
                       "UAT"
                   ]
               }
+            },
+            "addresses": {
+              "type": "object",
+              "description": "The addresses where the API can be accessed. Each property name of this object is the domain of the address, and the value of the property contains the remainder of the address information.",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "subdomain": {
+                      "type": "string",
+                      "description": "The subdomain of the address.",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string",
+                      "description": "The path of the address.",
+                      "minLength": 1
+                    },
+                    "envs": {
+                      "type": "string",
+                      "description": "The environments where the entity is available.",
+                      "minLength": 1
+                    }
+                  },
+                  "examples": [
+                    {
+                      "subdomain": "marketplace",
+                      "path": "/home",
+                      "envs": "dev qa stage prod"
+                    }
+                  ]
+                }
+              },
+              "examples": [
+                {
+                  "viabenefits.com": [
+                    {
+                      "subdomain": "my",
+                      "path": "/home",
+                      "envs": "dev qa stage prod"
+                    }
+                  ]
+                }
+              ]
             }
           },
           "$comment": "It may contain an optional deployment-environments property."

--- a/test/catalog-infos/invalid-apis.yml
+++ b/test/catalog-infos/invalid-apis.yml
@@ -215,3 +215,76 @@ spec:
   system: system:default/content-management
   definition: 
 ...
+
+---
+# Doc 17 - Empty metadata.addresses
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: content-mgmt-api-17
+  addresses:
+spec:
+  type: openapi
+  lifecycle: maintaining
+  system: system:default/content-management
+  definition: 
+    $text: https://content-management.io/manager/swagger/contentApi/swagger.json
+...
+
+---
+# Doc 18 - Empty metadata.addresses domain list
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: content-mgmt-api-18
+  addresses:
+    mktp.io:
+spec:
+  type: openapi
+  lifecycle: maintaining
+  system: system:default/content-management
+  definition: 
+    $text: https://content-management.io/manager/swagger/contentApi/swagger.json
+...
+
+---
+# Doc 19 - Invalid metadata.addresses domain list
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: content-mgmt-api-19
+  addresses:
+    mktp.io:
+      # 0 - Missing subdomain
+      - subdomain:
+        path: /
+        envs: dev
+      # 1 - Missing subdomain
+      - subdomain: api
+        path:
+        envs: dev
+      # 2 - Missing envs
+      - subdomain: api
+        path: /
+        envs:
+      # 3 - Empty subdomain
+      - subdomain: ''
+        path: /
+        envs: dev
+      # 4 - Empty subdomain
+      - subdomain: api
+        path: ''
+        envs: dev
+      # 5 - Empty envs
+      - subdomain: api
+        path: /
+        envs: ''
+spec:
+  type: openapi
+  lifecycle: maintaining
+  system: system:default/content-management
+  definition: 
+    $text: https://content-management.io/manager/swagger/contentApi/swagger.json
+  
+...
+---

--- a/test/catalog-infos/invalid-components.yml
+++ b/test/catalog-infos/invalid-components.yml
@@ -312,4 +312,70 @@ spec:
     - content-management-db        # Not in the right format
     - group:default/customization  # Right format but not a valid entity to depend on
 ...
+
+---
+# Doc 25 - Empty metadata.addresses
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: content-mfe-25
+  addresses:
+spec:
+  type: mfe
+  system: system:default/content-management
+  lifecycle: maintaining
+...
+
+---
+# Doc 26 - Empty metadata.addresses domain list
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: content-mfe-26
+  addresses:
+    mktp.io:
+spec:
+  type: mfe
+  system: system:default/content-management
+  lifecycle: maintaining
+...
+
+---
+# Doc 27 - Invalid metadata.addresses domain list
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: content-mfe-27
+  addresses:
+    mktp.io:
+      # 0 - Missing subdomain
+      - subdomain:
+        path: /
+        envs: dev
+      # 1 - Missing subdomain
+      - subdomain: api
+        path:
+        envs: dev
+      # 2 - Missing envs
+      - subdomain: api
+        path: /
+        envs:
+      # 3 - Empty subdomain
+      - subdomain: ''
+        path: /
+        envs: dev
+      # 4 - Empty subdomain
+      - subdomain: api
+        path: ''
+        envs: dev
+      # 5 - Empty envs
+      - subdomain: api
+        path: /
+        envs: ''
+spec:
+  type: mfe
+  system: system:default/content-management
+  lifecycle: maintaining
+  
+...
 ---

--- a/test/expected-markdown/invalid-apis.md
+++ b/test/expected-markdown/invalid-apis.md
@@ -23,3 +23,11 @@
 - Doc 15, Line 198, `API[content-mgmt-api-15]/spec` must have required property **definition**.
 - Doc 16, Line 216, `API[content-mgmt-api-16]/spec/definition` Is required and must be a string or an object with a $text, $json, or $yaml property.
   - See the [catalog info schema](https://github.com/im-open/validate-catalog-info/blob/main/schema/CatalogInfo.schema.json) for details and examples.
+- Doc 17, Line 220, `API[content-mgmt-api-17]/metadata/addresses` is an object that cannot be empty. Addresses should be have one or more domains as the property name and a corresponding list of address objects as the value for each domain property.
+- Doc 18, Line 235, `API[content-mgmt-api-18]/metadata/addresses/mktp.io` is an array that cannot be empty. It should contain at least one list item or be removed completely if not required.
+- Doc 19, Line 251, `API[content-mgmt-api-19]/metadata/addresses/mktp.io/0/subdomain` is a string that cannot be empty. It should be populated or be removed completely if not required.
+- Doc 19, Line 251, `API[content-mgmt-api-19]/metadata/addresses/mktp.io/1/path` is a string that cannot be empty. It should be populated or be removed completely if not required.
+- Doc 19, Line 251, `API[content-mgmt-api-19]/metadata/addresses/mktp.io/2/envs` is a string that cannot be empty. It should be populated or be removed completely if not required.
+- Doc 19, Line 251, `API[content-mgmt-api-19]/metadata/addresses/mktp.io/3/subdomain` cannot be empty if provided.
+- Doc 19, Line 251, `API[content-mgmt-api-19]/metadata/addresses/mktp.io/4/path` cannot be empty if provided.
+- Doc 19, Line 251, `API[content-mgmt-api-19]/metadata/addresses/mktp.io/5/envs` cannot be empty if provided.

--- a/test/expected-markdown/invalid-components.md
+++ b/test/expected-markdown/invalid-components.md
@@ -47,3 +47,11 @@
   - Expected Pattern: `<kind>:[<optional-namespace>/]<entity-name>` e.g. **resource:default/launchdarkly**, **component:front-end-tooling-mfe**
 - Doc 24, Line 310, `Component[content-mfe-24]/spec/dependsOn/2` value **group:default/customization** is invalid.
   - Expected Pattern: `<kind>:[<optional-namespace>/]<entity-name>` e.g. **resource:default/launchdarkly**, **component:front-end-tooling-mfe**
+- Doc 25, Line 317, `Component[content-mfe-25]/metadata/addresses` is an object that cannot be empty. Addresses should be have one or more domains as the property name and a corresponding list of address objects as the value for each domain property.
+- Doc 26, Line 330, `Component[content-mfe-26]/metadata/addresses/mktp.io` is an array that cannot be empty. It should contain at least one list item or be removed completely if not required.
+- Doc 27, Line 344, `Component[content-mfe-27]/metadata/addresses/mktp.io/0/subdomain` is a string that cannot be empty. It should be populated or be removed completely if not required.
+- Doc 27, Line 344, `Component[content-mfe-27]/metadata/addresses/mktp.io/1/path` is a string that cannot be empty. It should be populated or be removed completely if not required.
+- Doc 27, Line 344, `Component[content-mfe-27]/metadata/addresses/mktp.io/2/envs` is a string that cannot be empty. It should be populated or be removed completely if not required.
+- Doc 27, Line 344, `Component[content-mfe-27]/metadata/addresses/mktp.io/3/subdomain` cannot be empty if provided.
+- Doc 27, Line 344, `Component[content-mfe-27]/metadata/addresses/mktp.io/4/path` cannot be empty if provided.
+- Doc 27, Line 344, `Component[content-mfe-27]/metadata/addresses/mktp.io/5/envs` cannot be empty if provided.


### PR DESCRIPTION
# Summary of PR changes

Adding addresses metadata to Component and API kinds. These address metadata is used by a plugin in WTW's Backstage instance to display components served on different endpoints.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
