### PR TITLE
ARCH-2125 - Open Validation Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
 
       - name: Validate catalog-info.yml
         id: catalogInfo
-        uses: im-open/validate-catalog-info@v1.0.2
+        uses: im-open/validate-catalog-info@v1.0.3
         with:
           filename: ./docs/catalog-info.yml # Defaults to ./catalog-info.yml
           fail-if-errors: false             # Defaults to true

--- a/dist/index.js
+++ b/dist/index.js
@@ -29876,6 +29876,9 @@ var require_validate2 = __commonJS({
       }
     }
     function getYamlLineNumberOfError(errorPath, jsonDoc) {
+      if (!jsonDoc.validationMetadata) {
+        return null;
+      }
       if (!errorPath) {
         return jsonDoc.validationMetadata.doc;
       }
@@ -29928,7 +29931,9 @@ var require_validate2 = __commonJS({
       for (const ajvError of validateWithAjvFunc.errors) {
         const instancePath = ajvError.instancePath.replace('mktp.io~1', 'mktp.io/');
         const lineNumber = getYamlLineNumberOfError(instancePath, doc);
-        const itemId = `Doc ${docCount}, Line ${lineNumber}, \`${docId}${instancePath}\``;
+        const itemId = lineNumber
+          ? `Doc ${docCount}, Line ${lineNumber}, \`${docId}${instancePath}\``
+          : `Doc ${docCount}, \`${docId}${instancePath}\``;
         const schemaComment = ajvError.parentSchema && ajvError.parentSchema.$comment ? ajvError.parentSchema.$comment : null;
         const hasData = isErrorDataPresent(ajvError.data);
         switch (ajvError.keyword) {
@@ -30027,7 +30032,7 @@ ${ajvError.schema.$comment} e.g. '${propExamples}'`;
         catalogInfoDocs = jsYaml2.loadAll(catalogInfoTextAsYaml);
       } catch (error) {
         const errorMessage = `An error occurred converting the file to json: ${error.message}`;
-        core2.error(errorMessage, Object.assign(annotationOptions, { startLine: 0 }));
+        core2.error(errorMessage, annotationOptions ? Object.assign(annotationOptions, { startLine: 0 }) : null);
         return [errorMessage];
       }
       const numDocs = catalogInfoDocs.length;
@@ -30055,7 +30060,7 @@ Validating Doc #${docCount} - ${docId}`);
               if (!allCatalogInfoErrors.includes(error.message)) {
                 allCatalogInfoErrors.push(error.message);
                 const plainErrorMessage = error.message.replace(/`/g, '').replace(/'/g, '').replace(/\*/g, '');
-                core2.error(plainErrorMessage, Object.assign(annotationOptions, { startLine: error.line }));
+                core2.error(plainErrorMessage, annotationOptions ? Object.assign(annotationOptions, { startLine: error.line }) : null);
               }
             });
           } else {


### PR DESCRIPTION
# Summary of PR changes

Allow the validation function to be used by other workflows.  Allow for line numbers not being present and not sending in annotation options.  

This will allow the `validate-all-catalog-info-files` action to reuse the same validation function without generating the `validationMetadata` object for every file it wants to validate.  It also makes it so we aren't creating annotations on the catalog-info files it processes in bulk.


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
