### PR TITLE
ARCH-2125 - Tweak how annotation options are handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
 
       - name: Validate catalog-info.yml
         id: catalogInfo
-        uses: im-open/validate-catalog-info@v1.0.3
+        uses: im-open/validate-catalog-info@v1.0.4
         with:
           filename: ./docs/catalog-info.yml # Defaults to ./catalog-info.yml
           fail-if-errors: false             # Defaults to true

--- a/dist/index.js
+++ b/dist/index.js
@@ -30032,7 +30032,11 @@ ${ajvError.schema.$comment} e.g. '${propExamples}'`;
         catalogInfoDocs = jsYaml2.loadAll(catalogInfoTextAsYaml);
       } catch (error) {
         const errorMessage = `An error occurred converting the file to json: ${error.message}`;
-        core2.error(errorMessage, annotationOptions ? Object.assign(annotationOptions, { startLine: 0 }) : null);
+        if (annotationOptions) {
+          core2.error(errorMessage, Object.assign(annotationOptions, { startLine: 0 }));
+        } else {
+          core2.error(errorMessage);
+        }
         return [errorMessage];
       }
       const numDocs = catalogInfoDocs.length;
@@ -30060,7 +30064,11 @@ Validating Doc #${docCount} - ${docId}`);
               if (!allCatalogInfoErrors.includes(error.message)) {
                 allCatalogInfoErrors.push(error.message);
                 const plainErrorMessage = error.message.replace(/`/g, '').replace(/'/g, '').replace(/\*/g, '');
-                core2.error(plainErrorMessage, annotationOptions ? Object.assign(annotationOptions, { startLine: error.line }) : null);
+                if (annotationOptions) {
+                  core2.error(plainErrorMessage, Object.assign(annotationOptions, { startLine: error.line }));
+                } else {
+                  core2.error(plainErrorMessage);
+                }
               }
             });
           } else {

--- a/src/validate.js
+++ b/src/validate.js
@@ -258,7 +258,12 @@ async function processCatalogInfoFile(core, jsYaml, ajv, catalogInfoTextAsYaml, 
     catalogInfoDocs = jsYaml.loadAll(catalogInfoTextAsYaml);
   } catch (error) {
     const errorMessage = `An error occurred converting the file to json: ${error.message}`;
-    core.error(errorMessage, annotationOptions ? Object.assign(annotationOptions, { startLine: 0 }) : null);
+    if (annotationOptions) {
+      core.error(errorMessage, Object.assign(annotationOptions, { startLine: 0 }));
+    } else {
+      core.error(errorMessage);
+    }
+
     return [errorMessage];
   }
 
@@ -294,7 +299,12 @@ async function processCatalogInfoFile(core, jsYaml, ajv, catalogInfoTextAsYaml, 
           if (!allCatalogInfoErrors.includes(error.message)) {
             allCatalogInfoErrors.push(error.message);
             const plainErrorMessage = error.message.replace(/`/g, '').replace(/'/g, '').replace(/\*/g, '');
-            core.error(plainErrorMessage, annotationOptions ? Object.assign(annotationOptions, { startLine: error.line }) : null);
+
+            if (annotationOptions) {
+              core.error(plainErrorMessage, Object.assign(annotationOptions, { startLine: error.line }));
+            } else {
+              core.error(plainErrorMessage);
+            }
           }
         });
       } else {


### PR DESCRIPTION
# Summary of PR changes

- GitHub does not like it when a null is sent in so use if/else instead of ternary


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
